### PR TITLE
Fix typo in one XML tag

### DIFF
--- a/module06/get_interfaces.xml
+++ b/module06/get_interfaces.xml
@@ -1,5 +1,5 @@
 <filter>
   <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
     <interface></interface>
-  </interface>
+  </interfaces>
 </filter>


### PR DESCRIPTION
Hi, I've noticed a small typo in closure  </interfaces> tag. >> Missing 's'. 