### PR TITLE
Fix for issue 15 to ignore Unified APs

### DIFF
--- a/module05/05-lab03-python/apic_em_code_1.py
+++ b/module05/05-lab03-python/apic_em_code_1.py
@@ -46,7 +46,7 @@ def get_device_id(token, url):
     # Iterate over the response and find first device with access role.
     # Return ID number of the first device matching the criteria
     for item in response['response']:
-        if item['role'] == 'ACCESS':
+        if item['role'] == 'ACCESS' and not item['family'] == 'Unified AP':
             return item['id']
 
 			

--- a/module05/05-lab03-python/apic_em_code_2.py
+++ b/module05/05-lab03-python/apic_em_code_2.py
@@ -46,7 +46,7 @@ def get_device_id(token, url):
     # Iterate over the response and find first device with access role.
     # Return ID number of the first device matching the criteria
     for item in response['response']:
-        if item['role'] == 'ACCESS':
+        if item['role'] == 'ACCESS' and not item['family'] == 'Unified AP':
             return item['id']
 
 			


### PR DESCRIPTION
Proposed fix for issue #15 where the script will crash if the first Access device is a Unified AP, as was the case on the sandbox APIC-EM. 